### PR TITLE
Include debug info in release builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ exclude = [".*", "deny.toml", "rustfmt.toml", "Makefile"]
 [profile.release]
 lto = true
 panic = "abort"
-strip = true
+debug = true
 
 [profile.dev]
 opt-level = 3


### PR DESCRIPTION
This helps debugging, at the cost of making binaries larger. Previously, with strip=true the sizes were 3.6M for sybil and 2.7M for sybild, with this change sybil is 55M and sybild 37M.